### PR TITLE
ignore missing-import in mypy

### DIFF
--- a/.github/workflows/monthly.yml
+++ b/.github/workflows/monthly.yml
@@ -24,6 +24,6 @@ jobs:
         pre-commit autoupdate -c "{{cookiecutter.project_name}}/.pre-commit-config.yaml"
         pre-commit autoupdate -c "{{cookiecutter.project_name}}/.pre-commit-config-cruft.yaml"
     - name: Create Pull Request
-      uses: peter-evans/create-pull-request@v6
+      uses: peter-evans/create-pull-request@v7
       with:
         title: pre-commit autoupdate

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -42,7 +42,7 @@ jobs:
     - name: Create my-package
       run: cruft create . --output-dir .. -y
     - name: Install Conda environment with Micromamba
-      uses: mamba-org/setup-micromamba@v1
+      uses: mamba-org/setup-micromamba@v2
       with:
         environment-file: ../my-package/ci/environment-ci.yml
         environment-name: my-package-env

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
   - id: check-added-large-files
   - id: mixed-line-ending
 - repo: https://github.com/executablebooks/mdformat
-  rev: 0.7.19
+  rev: 0.7.21
   hooks:
   - id: mdformat
 - repo: https://github.com/macisamuele/language-formatters-pre-commit-hooks

--- a/{{cookiecutter.project_name}}/.github/workflows/on-push.yml
+++ b/{{cookiecutter.project_name}}/.github/workflows/on-push.yml
@@ -66,7 +66,7 @@ jobs:
     - name: Get current date
       id: date
       run: echo "date=$(date +%Y-%m-%d)" >> "${GITHUB_OUTPUT}"
-    - uses: mamba-org/setup-micromamba@v1
+    - uses: mamba-org/setup-micromamba@v2
       with:
         environment-file: ci/combined-environment-ci.yml
         environment-name: DEVELOP
@@ -95,7 +95,7 @@ jobs:
     - name: Get current date
       id: date
       run: echo "date=$(date +%Y-%m-%d)" >> "${GITHUB_OUTPUT}"
-    - uses: mamba-org/setup-micromamba@v1
+    - uses: mamba-org/setup-micromamba@v2
       with:
         environment-file: ci/combined-environment-ci.yml
         environment-name: DEVELOP
@@ -124,7 +124,7 @@ jobs:
     - name: Get current date
       id: date
       run: echo "date=$(date +%Y-%m-%d)" >> "${GITHUB_OUTPUT}"
-    - uses: mamba-org/setup-micromamba@v1
+    - uses: mamba-org/setup-micromamba@v2
       with:
         environment-file: ci/combined-environment-ci.yml
         environment-name: DEVELOP

--- a/{{cookiecutter.project_name}}/pyproject.toml
+++ b/{{cookiecutter.project_name}}/pyproject.toml
@@ -22,6 +22,7 @@ readme = "README.md"
 branch = true
 
 [tool.mypy]
+ignore_missing_imports = true
 strict = {{ cookiecutter.mypy_strict | string | lower }}
 
 [tool.ruff]


### PR DESCRIPTION
Ignoring missing imports in Type-checks to avoid the constant hassle of having to add ``  # type: ignore`` after imports

@pag1pag please merge if ok; then all packages can be updated with ``make template-update``